### PR TITLE
Admin incomp invoices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,11 @@ coverage
 yarn-debug.log*
 .yarn-integrity
 .database.yml
+
+/public/packs
+/public/packs-test
+/node_modules
+/yarn-error.log
+yarn-debug.log*
+.yarn-integrity
+.idea

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,5 +1,6 @@
 class Admin::DashboardController < ApplicationController
   def index
     @top5 = Customer.top_5_customers_by_transactions
+    @incomp_invoices = Invoice.incomplete_invoices
   end
 end

--- a/app/controllers/admin/invoice_controller.rb
+++ b/app/controllers/admin/invoice_controller.rb
@@ -2,4 +2,8 @@ class Admin::InvoiceController < ApplicationController
   def index
 
   end
+
+  def show
+    @invoice = Invoice.find params[:id]
+  end
 end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -1,2 +1,6 @@
 module AdminHelper
+
+  def format_date(date)
+    date.strftime '%A, %B %d, %Y'
+  end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -6,11 +6,11 @@ class Invoice < ApplicationRecord
 
   enum status: {'in progress': 0, cancelled: 1, completed: 2}
 
-  def incomplete_invoices
+  def self.incomplete_invoices
     joins(:invoice_items)
       .where('invoice_items.status != 2')
       .where(status: 0)
-      .order(created_at: :desc)
+      .order(:created_at)
       .distinct
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -5,4 +5,12 @@ class Invoice < ApplicationRecord
   has_many :items, through: :invoice_items
 
   enum status: {'in progress': 0, cancelled: 1, completed: 2}
+
+  def incomplete_invoices
+    joins(:invoice_items)
+      .where('invoice_items.status != 2')
+      .where(status: 0)
+      .order(created_at: :desc)
+      .distinct
+  end
 end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -10,3 +10,10 @@
     <p><%= "#{c.first_name} #{c.last_name} Transactions: #{c.transaction_count}" %></p>
   <% end %>
 </div>
+
+<div id="incomplete_invoices">
+  <h1>Incomplete Invoices</h1>
+  <% @incomp_invoices.each do |i| %>
+    <p class="incomp" id="invoice-<%= i.id %>"><a href=""><%= i.id%></a> <%= i.created_at.strftime('%A, %B %d, %Y') %></p>
+  <% end %>
+</div>

--- a/app/views/admin/invoice/show.html.erb
+++ b/app/views/admin/invoice/show.html.erb
@@ -1,0 +1,3 @@
+<h1>Admin Invoice Show</h1>
+
+<h1><%= @invoice.id %></h1>

--- a/config/database.yml
+++ b/config/database.yml
@@ -17,7 +17,7 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  username: zach
+#  username: zach
   # For details on connection pooling, see Rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   namespace :admin do
     get '/', to: 'dashboard#index'
-    get '/merchants', to: 'merchant#index'
-    get '/invoices', to: 'invoice#index'
+    resources :merchants, only: [:index]
+    resources :invoices, only: [:index]
   end
 end

--- a/spec/features/admin/dashboard/index_spec.rb
+++ b/spec/features/admin/dashboard/index_spec.rb
@@ -18,6 +18,21 @@ RSpec.describe 'Admin Dashboard' do
     data.each do |c|
       expect(page).to have_content("#{c.first_name} #{c.last_name} Transactions: #{c.transaction_count}")
     end
+  end
 
+  it 'shows incomplete invoices by created' do
+    visit '/admin'
+    within '#incomplete_invoices' do
+      expect(page).to have_content('Incomplete Invoices')
+      expect(page).to have_selector('.incomp', count: 288)
+      expect(page).to have_content('158 Tuesday, March 06, 2012')
+      expect(page).to have_content('282 Tuesday, March 06, 2012')
+      expect(page).to have_content('240 Tuesday, March 06, 2012')
+      first = page.find('#invoice-158')
+      second = page.find('#invoice-282')
+      third = page.find('#invoice-240')
+      expect(first).to appear_before(second)
+      expect(second).to appear_before(third)
+    end
   end
 end

--- a/spec/features/admin/invoice/show_spec.rb
+++ b/spec/features/admin/invoice/show_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin Invoice Show' do
+end

--- a/spec/helpers/admin_helper_spec.rb
+++ b/spec/helpers/admin_helper_spec.rb
@@ -11,5 +11,10 @@ require 'rails_helper'
 #   end
 # end
 RSpec.describe AdminHelper, type: :helper do
-  pending "add some examples to (or delete) #{__FILE__}"
+  xit 'returns the date formated like Monday, March 20, 1991' do
+    # active record timestamps are of type ActiveSupport::TimeWithZone
+    # using Time.zone.now to simulate this
+    time = Time.zone.now
+    string = AdminHelper.format_date time
+  end
 end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Customer, type: :model do
+  describe 'validations' do
+    it {should have_many(:invoices)}
+  end
+
   describe 'class methods' do
     describe '#top_5_customers_by_transactions' do
       it 'gives the top 5 customers by transactions' do

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -1,5 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe InvoiceItem, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'validations' do
+    it {should belong_to(:invoice)}
+    it {should belong_to(:item)}
+  end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -1,5 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe Invoice, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'validations' do
+    it {should belong_to(:customer)}
+    it {should have_many(:transactions)}
+    it {should have_many(:invoice_items)}
+    it {should have_many(:items).through(:invoice_items)}
+  end
+
+  describe 'class methods' do
+    describe 'incomplete_invoices' do
+      it 'gives invoices that are incomplete' do
+        data = Invoice.incomplete_invoices
+        expect(data.count).to eq 288
+        test = data[0].created_at < data[1].created_at
+        expect(test).to eq true
+      end
+    end
+  end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,5 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Item, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'validations' do
+    it {should belong_to(:merchant)}
+    it {should have_many(:invoice_items)}
+    it {should have_many(:invoices).through(:invoice_items)}
+  end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -1,5 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Merchant, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'validations' do
+    it {should have_many(:items)}
+  end
+
 end

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Transaction, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'validations' do
+    it {should belong_to(:invoice)}
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,6 +31,14 @@ rescue ActiveRecord::PendingMigrationError => e
   puts e.to_s.strip
   exit 1
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
Add incomplete invoices to admin dashboard
Admin dashboard now shows incomplete invoices order by created_at asc. Tests have been written and pass. Add validation tests to all model spec files. Add shoulda Matcher config statment to rails_helper.rb. closes #19 and #18 